### PR TITLE
updating dockerfiles to use correct workdirs

### DIFF
--- a/docker/dev/environment/Dockerfile
+++ b/docker/dev/environment/Dockerfile
@@ -14,7 +14,7 @@ ADD https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini /usr/
 
 RUN chmod +x /usr/bin/tini && \
     mkdir /app && \
-    pip install --user pipenv 
+    pip install --user pipenv
 
 ADD ACGCrossingApp/ /app/
 ADD scripts/ /scripts/

--- a/docker/dev/runtime/Dockerfile
+++ b/docker/dev/runtime/Dockerfile
@@ -9,6 +9,7 @@ ARG BRANCH_NAME
 ARG PROJ_ROOT
 
 RUN rm -rf /app
+WORKDIR /live-app
 ENTRYPOINT [ "/scripts/entrypoint.sh" ]
 
 LABEL "Commit Hash"="${COMMIT_HASH}"

--- a/docker/prod/Dockerfile
+++ b/docker/prod/Dockerfile
@@ -1,27 +1,30 @@
-# Stage 1
-# - Make sure pipenv is installed
-# - Check if Pipfile has changed
-# - If it has, reinstall dependencies so it's FRESH
-# - Generate a new Pipefile.lock and update it in the project
-# - Now we have an updated environment
-# ---------------------------------------------------------
-FROM python:3 as build-system
-
-RUN mkdir /code && \
-    pip install --user pipenv
-
-ADD ACGCrossingApp /code
-
-# Stage 2
-# ---------------------------------------------------------
-FROM build-system as runtime
+FROM python:3
 
 LABEL "Maintainer"="CrossWatch Team"
 
 ARG COMMIT_HASH
 ARG BRANCH_NAME
+ARG PROJ_ROOT
 
 ENV PYTHONUNBUFFERED 1
+ENV PATH="/root/.local/bin:${PATH}"
+
+ENV TINI_VERSION v0.18.0
+ADD https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini /usr/bin/tini
+
+RUN chmod +x /usr/bin/tini && \
+    mkdir /app && \
+    pip install --user pipenv
+
+ADD ACGCrossingApp/ /app/
+ADD scripts/ /scripts/
+
+WORKDIR /app
+RUN chmod 755 /scripts/* && \
+    pipenv lock && \
+    pipenv install --system
+
+ENTRYPOINT [ "/scripts/entrypoint.sh" ]
 
 LABEL "Commit Hash"="${COMMIT_HASH}"
 LABEL "Commit URL"="https://github.com/jessjohn/acg-crossing-app/commit/${COMMIT_HASH}"


### PR DESCRIPTION
- Workdir in the environment dockerfile is set to app because we load the app in there just to build the environment from the pipfile
- when we actually run the app with live reload, we want the workdir to be live-app

Bonus, kind of inconsequential things:
- also removed some whitespaces and updated the prod environment to just grab the app as it is, build the environment and make it runnable using the same scripts as the dev stuff. 
- That will definitely need more work to make it turn on but its a start and we're not using it yet anyway